### PR TITLE
Add mission control helper with fail tolerance

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ in `~/go/bin/linux_arm`.
   -d, --exclude-node=            don't use this node for routing (can be specified multiple times)
       --to=                      try only this channel as target (should satisfy other constraints too; can be specified multiple times)
       --from=                    try only this channel as source (should satisfy other constraints too; can be specified multiple times)
+      --fail-tolerance=        if a channel failed before during this rebalance but chosen again by lnd, and the forward amount differs by less than this ppm, exclude the channel
       --allow-unbalance-from     let the source channel go below 50% local liquidity, use if you want to drain a channel; you should also set --pfrom to >50
       --allow-unbalance-to       let the target channel go above 50% local liquidity, use if you want to refill a channel; you should also set --pto to >50
   -s, --stat=                    save successful rebalance information to the specified CSV file

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/fatih/color v1.13.0
+	github.com/gofrs/flock v0.8.1
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/lightninglabs/lndclient v0.15.1-0
 	github.com/lightningnetwork/lnd v0.15.1-beta.rc1
@@ -43,7 +44,6 @@ require (
 	github.com/fergusstrange/embedded-postgres v1.10.0 // indirect
 	github.com/form3tech-oss/jwt-go v3.2.3+incompatible // indirect
 	github.com/go-errors/errors v1.0.1 // indirect
-	github.com/gofrs/flock v0.8.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -858,7 +858,6 @@ golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/mission_ctl.go
+++ b/mission_ctl.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/lightningnetwork/lnd/lnrpc"
+)
+
+func (r *regolancer) addFailedChan(fromStr string, toStr string, amount int64) {
+	r.mcCache[fromStr+toStr] = amount
+}
+
+func (r *regolancer) validateRoute(route *lnrpc.Route) error {
+	prevHopPK := r.myPK
+	for _, h := range route.Hops {
+		hopPK := h.PubKey
+		if fp, ok := r.mcCache[prevHopPK+hopPK]; ok && 1e6-h.AmtToForwardMsat*1e6/fp < params.FailTolerance {
+			from, err := hex.DecodeString(prevHopPK)
+			if err != nil {
+				return err
+			}
+			to, err := hex.DecodeString(hopPK)
+			if err != nil {
+				return err
+			}
+			r.failedPairs = append(r.failedPairs, &lnrpc.NodePair{From: from, To: to})
+			return fmt.Errorf("chan %d failed before with %d msat and will not be used anymore during this rebalance, payment attempt with %d msat cancelled", h.ChanId, fp, h.AmtToForwardMsat)
+		}
+		prevHopPK = hopPK
+	}
+	return nil
+}


### PR DESCRIPTION
Lnd sometimes returns routes that are very likely to fail because one of the channels in them failed before with a slightly bigger amount. It usually happens because the same channel was chosen in another route with less total fees so the amount being pushed through that channel is lower and _technically_ it can succeed. In practice it never happens because the difference is often less than 10 sats. To save time we can exclude such channels if they're hit again with a similar amount. The new parameter `--fail-tolerance` (set to 1000 by default) allows to set this margin of autoban in ppm.

For example, you have it set to 100 and you rebalance 100 000 sats. The attempt fails on some channel with amount 100 023 (because it includes fees), but then this channel is picked again with different fees so the amount would be slightly different. If this new amount falls between 100 012.9977 (`100 023 - 100 023 * 100ppm / 1 000 000`) and 100 023, then this channel will be automatically banned for this run time without even trying. In other words, in this case the fail tolerance is 100ppm from 100 023 which equals 10.0023 sats. If the amount to pay through this channel differs by more than 10.0023 (in our example) it will be tried normally, otherwise it's banned.

Banned channels are ignored during path finding but they're not stored to disk as of now. When you start regolancer again this channel will not be ignored.