### PR TITLE
add to-node and from-node

### DIFF
--- a/channels.go
+++ b/channels.go
@@ -66,24 +66,24 @@ func (r *regolancer) getChannelCandidates(fromPerc, toPerc, amount int64) error 
 		if _, ok := r.excludeBoth[c.ChanId]; ok {
 			continue
 		}
-		if c.LocalBalance < c.Capacity*toPerc/100 && (params.AllowUnbalanceTo ||
-			c.LocalBalance+amount < c.Capacity/2) {
-			if _, ok := r.excludeIn[c.ChanId]; ok {
-				continue
-			}
+		if _, ok := r.excludeIn[c.ChanId]; !ok {
 			if _, ok := r.toChannelId[c.ChanId]; ok || len(r.toChannelId) == 0 {
-				r.toChannels = append(r.toChannels, c)
+				if c.LocalBalance < c.Capacity*toPerc/100 && (params.AllowUnbalanceTo ||
+					c.LocalBalance+amount < c.Capacity/2) {
+					r.toChannels = append(r.toChannels, c)
+				}
 			}
+
 		}
-		if c.RemoteBalance < c.Capacity*fromPerc/100 &&
-			(params.AllowUnbalanceFrom ||
-				c.RemoteBalance+amount < c.Capacity/2) {
-			if _, ok := r.excludeOut[c.ChanId]; ok {
-				continue
-			}
+		if _, ok := r.excludeOut[c.ChanId]; !ok {
 			if _, ok := r.fromChannelId[c.ChanId]; ok || len(r.fromChannelId) == 0 {
-				r.fromChannels = append(r.fromChannels, c)
+				if c.RemoteBalance < c.Capacity*fromPerc/100 &&
+					(params.AllowUnbalanceFrom ||
+						c.RemoteBalance+amount < c.Capacity/2) {
+					r.fromChannels = append(r.fromChannels, c)
+				}
 			}
+
 		}
 	}
 	for _, fc := range r.fromChannels {


### PR DESCRIPTION
This PR includes the two new handles `to-node` and `from-node`. I decided to use them in combination with `to` and `from` which currently take Channel Ids as input. Those handles will take all channels of the specified node and apply the channel criteria to each of them.  

In addition it includes a change that will force each channel to be considered as source and target. This will be done in a separate PR I just including it here, for your opinions on it.