### PR TITLE
Make timeouts customizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ rebalance-lnd](https://github.com/accumulator/rebalance-lnd).
 # Features
 
 - automatically pick source and target channel by local/remote liquidity ratio
-- retry indefinitely until it succeeds or 6 hours pass (currently hardcoded)
-- payments time out after 5 minutes (currently hardcoded) so if something's
-  stuck the process will continue shortly
+- retry indefinitely until it succeeds or 6 hours pass (by default)
+- payments time out after 5 minutes (by default) so if something's stuck the
+  process will continue shortly
+- timeouts can be customized
 - JSON/TOML config file to set some defaults you prefer
 - optional route probing using binary search to rebalance a smaller amount
 - optional rapid rebalancing using the same route for further rebalances 
@@ -94,6 +95,10 @@ in `~/go/bin/linux_arm`.
       --node-cache-filename=     save and load other nodes information to this file, improves cold start performance
       --node-cache-lifetime=     nodes with last update older than this time (in minutes) will be removed from cache after loading it (default: 1440)
       --node-cache-info          show red and cyan 'x' characters in routes to indicate node cache misses and hits respectively
+      --timeout-rebalance=       max rebalance session time in minutes
+      --timeout-attempt=         max attempt time in minutes
+      --timeout-info=            max general info query time (local channels, node id etc.) in seconds
+      --timeout-route=           max channel selection and route query time in seconds
   -v, --version                  show program version and exit
 ```
 

--- a/channels.go
+++ b/channels.go
@@ -21,7 +21,7 @@ func formatChannelPair(a, b uint64) string {
 }
 
 func (r *regolancer) getChannels(ctx context.Context) error {
-	ctx, cancel := context.WithTimeout(ctx, time.Second*30)
+	ctx, cancel := context.WithTimeout(ctx, time.Second*time.Duration(params.TimeoutRoute))
 	defer cancel()
 	channels, err := r.lnClient.ListChannels(ctx, &lnrpc.ListChannelsRequest{ActiveOnly: true, PublicOnly: true})
 	if err != nil {

--- a/config.json.sample
+++ b/config.json.sample
@@ -36,5 +36,9 @@
         "821280210373779139",
         "757806x673x1",
         "03cde60a6323f7122d5178255766e38114b4722ede08f7c9e0c5df9b912cc201d6"
-    ]
+    ],
+    "timeout_rebalance": 360,
+    "timeout_attempt": 5,
+    "timeout_info": 30,
+    "timeout_route": 30
 }

--- a/config.toml.sample
+++ b/config.toml.sample
@@ -47,3 +47,8 @@ lost_profit = true
     "821280210377179136",
     "03271338633d2d37b285dae4df40b413d8c6c791fbee7797bc5dc70812196d7d5c"
 ]
+
+timeout_rebalance = 360
+timeout_attempt = 5
+timeout_info = 30
+timeout_route = 30

--- a/payment.go
+++ b/payment.go
@@ -81,7 +81,7 @@ func (r *regolancer) pay(ctx context.Context, amount int64, minAmount int64,
 		}
 		prevHop := route.Hops[result.Failure.FailureSourceIndex-1]
 		failedHop := route.Hops[result.Failure.FailureSourceIndex]
-		nodeCtx, cancel := context.WithTimeout(ctx, time.Minute)
+		nodeCtx, cancel := context.WithTimeout(ctx, time.Second*time.Duration(params.TimeoutInfo))
 		defer cancel()
 		node1, err := r.getNodeInfo(nodeCtx, prevHop.PubKey)
 		node1name := ""

--- a/routes.go
+++ b/routes.go
@@ -89,7 +89,7 @@ func (r *regolancer) calcFeeMsat(ctx context.Context, from, to uint64,
 }
 
 func (r *regolancer) getRoutes(ctx context.Context, from, to uint64, amtMsat int64) ([]*lnrpc.Route, int64, error) {
-	routeCtx, cancel := context.WithTimeout(ctx, time.Second*30)
+	routeCtx, cancel := context.WithTimeout(ctx, time.Second*time.Duration(params.TimeoutRoute))
 	defer cancel()
 	feeMsat, lastPKstr, err := r.calcFeeMsat(routeCtx, from, to, amtMsat)
 	if err != nil {


### PR DESCRIPTION
Add four timeouts for different aspects: global session, one attempt, info retrieval and route search. The defaults are in the sample files.