### PR TITLE
Add (DEPRECATED) info to the Parameters list

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ in `~/go/bin/linux_arm`.
       --to=                      try only this channel or node as target (should satisfy other constraints too; can be specified multiple times)
       --from=                    try only this channel or node as source (should satisfy other constraints too; can be specified multiple times)
       --fail-tolerance=          if a channel failed before during this rebalance but chosen again by lnd, and the forward amount differs by less than this ppm, exclude the channel
-      --allow-unbalance-from     let the source channel go below 50% local liquidity, use if you want to drain a channel; you should also set --pfrom to >50
-      --allow-unbalance-to       let the target channel go above 50% local liquidity, use if you want to refill a channel; you should also set --pto to >50
+      --allow-unbalance-from     (DEPRECATED) let the source channel go below 50% local liquidity, use if you want to drain a channel; you should also set --pfrom to >50
+      --allow-unbalance-to       (DEPRECATED) let the target channel go above 50% local liquidity, use if you want to refill a channel; you should also set --pto to >50
   -s, --stat=                    save successful rebalance information to the specified CSV file
       --node-cache-filename=     save and load other nodes information to this file, improves cold start performance
       --node-cache-lifetime=     nodes with last update older than this time (in minutes) will be removed from cache after loading it (default: 1440)


### PR DESCRIPTION
Since version 1.8.0 --allow-unbalance-from and --allow-unbalance-to are deprecated and enabled by default. Therefore we should state this also in the Parameters list within the readme file.