### PR TITLE
Add non-zero exit codes on rebalance failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.2]
+### Added
+- Exit codes for failed rebalances (2 for global timeout and 1 for all
+  other reasons)
 ## [1.9.1]
 ### Fixed
 - Probing doesn't return actual learned value and as such payment never happens


### PR DESCRIPTION
Fixes #31. I'm not sure if we need to return different codes for different situations (few programs do that actually) so a simple zero (success) and non-zero (failure, in our case it's just 1) should suffice. 0 is returned if at least one payment succeeded, rapid rebalance doesn't affect it as it's not guaranteed by its nature. 1 is returned for any error that caused the program to stop working: any timeout except attempt timeout, no routes, no channel pairs, no source/target channels etc. 1 is also returned if any error prevented the program from running at all (wrong option values or option names, contradicting parameters and so on). `--help` and `--info` return 0 if they don't fail for an internal reason but if you use regolancer in scripts that shouldn't matter.

EDIT: if the whole rebalance times out the return code is 2, could be useful to know if it's still possible to launch it again and eventually find a working route. Code 1 means we're more or less confident it's not possible to rebalance right now, if regolancer is run in a loop getting 1 means it's rational to wait for a few hours before trying again; the balances in the network would shift and you might find a route by then. Code 2 means we stopped trying due to trying for too long and it's still possible to continue.