### PR TITLE
add amount when rapid rebalancing finished

### DIFF
--- a/main.go
+++ b/main.go
@@ -205,7 +205,7 @@ func tryRebalance(ctx context.Context, r *regolancer, attempt *int) (err error,
 		if err == nil {
 
 			if params.AllowRapidRebalance {
-				rebalanceResult, _ := tryRapidRebalance(ctx, r, from, to, route, amt, feeMsat)
+				rebalanceResult, _ := tryRapidRebalance(ctx, r, from, to, route, amt, route.TotalFeesMsat)
 
 				if rebalanceResult.successfulAttempts > 0 {
 					log.Printf("%s rapid rebalances were successful, total amount: %s (fee: %s sat | %s ppm)\n",
@@ -370,7 +370,7 @@ func tryRapidRebalance(ctx context.Context, r *regolancer, from, to uint64,
 		} else {
 			result.successfulAttempts++
 			result.successfulAmt += amt
-			result.paidFeeMsat += route.GetTotalFeesMsat()
+			result.paidFeeMsat += route.TotalFeesMsat
 		}
 	}
 	return result, nil


### PR DESCRIPTION
Adds The final Amount after Rapid Rebalances finished successfully.

Example:

```
2022/12/10 01:27:49 Rebalance failed with error: TEMPORARY_CHANNEL_FAILURE @ 1
2022/12/10 01:27:49 6 rapid rebalances were successful, Total Amount Rebalanced: 300000 sats
2022/12/10 01:27:49 Finished rapid rebalancing
2022/12/10 01:27:49 Saving node cache to nodecache.db
```