### PR TITLE
add exclusive lock when writing to Statfile

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -34,7 +34,7 @@ func (r *regolancer) loadNodeCache(filename string, exp int, doLock bool) error 
 		defer l.Unlock()
 
 		if err != nil {
-			return fmt.Errorf("error take shared lock on file %s: %s", filename, err)
+			return fmt.Errorf("error taking shared lock on file %s: %s", filename, err)
 		}
 	}
 	f, err := os.Open(filename)
@@ -69,7 +69,7 @@ func (r *regolancer) saveNodeCache(filename string, exp int) error {
 	defer l.Unlock()
 
 	if err != nil {
-		return fmt.Errorf("error take exclusive lock on file %s: %s", filename, err)
+		return fmt.Errorf("error taking exclusive lock on file %s: %s", filename, err)
 	}
 
 	old := regolancer{nodeCache: map[string]cachedNodeInfo{}}

--- a/payment.go
+++ b/payment.go
@@ -135,7 +135,7 @@ func (r *regolancer) pay(ctx context.Context, amount int64, minAmount int64,
 			defer l.Unlock()
 
 			if err != nil {
-				return fmt.Errorf("error take exclusive lock on file %s: %s", r.statFilename, err)
+				return fmt.Errorf("error taking exclusive lock on file %s: %s", r.statFilename, err)
 			}
 
 			_, err = os.Stat(r.statFilename)

--- a/payment.go
+++ b/payment.go
@@ -129,7 +129,16 @@ func (r *regolancer) pay(ctx context.Context, amount int64, minAmount int64,
 		log.Printf("Success! Paid %s in fees, %s ppm",
 			formatFee(result.Route.TotalFeesMsat), formatFeePPM(result.Route.TotalAmtMsat, result.Route.TotalFeesMsat))
 		if r.statFilename != "" {
-			_, err := os.Stat(r.statFilename)
+
+			l := lock()
+			err := l.Lock()
+			defer l.Unlock()
+
+			if err != nil {
+				return fmt.Errorf("error take exclusive lock on file %s: %s", r.statFilename, err)
+			}
+
+			_, err = os.Stat(r.statFilename)
 			f, ferr := os.OpenFile(r.statFilename, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
 			if ferr != nil {
 				logErrorF("Error saving rebalance stats to %s: %s", r.statFilename, ferr)


### PR DESCRIPTION
This PR adds a mutex lock when writing to the StatFile of the successful rebalances. It uses the same lock file than the NodeCache files. 