### PR TITLE
add goreleaser and dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.json
 *.cert
 regolancer*
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,126 @@
+before: 
+  hooks:
+    - go mod tidy
+    - go mod verify
+    - go mod download
+
+builds:
+  - goos:
+      - linux
+      - windows
+      - darwin
+      - freebsd
+
+    goarch:
+      - amd64
+      - arm
+      - arm64
+
+    goarm:
+      - 6
+
+    env:
+      - CGO_ENABLED=0
+
+    binary: regolancer
+
+checksum:
+  name_template: '{{ tolower .ProjectName }}_{{.Version}}_checksums.txt'
+
+snapshot:
+  name_template: SNAPSHOT-{{ .Commit }}
+
+archives:
+  - name_template: "{{ tolower .ProjectName }}_{{.Version}}_{{.Os}}-{{.Arch}}"
+    replacements:
+      darwin: macOS
+      linux: Linux
+      windows: Windows
+      freebsd: FreeBSD
+
+    files:
+      - LICENSE
+      - README.md
+      - CHANGELOG.md
+      - config.toml.sample
+      - config.json.sample
+
+    format: tar.gz
+    format_overrides:
+      - goos: windows
+        format: zip
+
+changelog:
+  # Set this to true if you don't want any changelog at all.
+  # Warning: this will also ignore any changelog files passed via `--release-notes`,
+  # and will render an empty changelog.
+  # This may result in an empty release notes on GitHub/GitLab/Gitea.
+  skip: false
+ 
+# dockers:
+#   # https://goreleaser.com/customization/docker/
+#   - use: buildx
+#     goos: linux
+#     goarch: amd64
+#     image_templates:
+#       - "ziggie1984/{{ .ProjectName }}:{{ .Version }}-amd64"
+#       - "ziggie1984/{{ .ProjectName }}:latest-amd64"
+#     build_flag_templates:
+#       - "--platform=linux/amd64"
+#       - "--label=org.opencontainers.image.created={{.Date}}"
+#       - "--label=org.opencontainers.image.title={{.ProjectName}}"
+#       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+#       - "--label=org.opencontainers.image.version={{.Version}}"
+#   - use: buildx
+#     goos: linux
+#     goarch: arm64
+#     image_templates:
+#       - "ziggie1984/{{ .ProjectName }}:{{ .Version }}-arm64v8"
+#       - "ziggie1984/{{ .ProjectName }}:latest-arm64v8"
+#     build_flag_templates:
+#       - "--platform=linux/arm64/v8"
+#       - "--label=org.opencontainers.image.created={{.Date}}"
+#       - "--label=org.opencontainers.image.title={{.ProjectName}}"
+#       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+#       - "--label=org.opencontainers.image.version={{.Version}}"
+#   - use: buildx
+#     goos: linux
+#     goarch: arm
+#     goarm: 6
+#     image_templates:
+#       - "ziggie1984/{{ .ProjectName }}:{{ .Version }}-armv6"
+#       - "ziggie1984/{{ .ProjectName }}:latest-armv6"
+#     build_flag_templates:
+#       - "--platform=linux/arm/v6"
+#       - "--label=org.opencontainers.image.created={{.Date}}"
+#       - "--label=org.opencontainers.image.title={{.ProjectName}}"
+#       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+#       - "--label=org.opencontainers.image.version={{.Version}}"
+#   - use: buildx
+#     goos: linux
+#     goarch: arm
+#     goarm: 7
+#     image_templates:
+#       - "ziggie1984/{{ .ProjectName }}:{{ .Version }}-armv7"
+#       - "ziggie1984/{{ .ProjectName }}:latest-armv7"
+#     build_flag_templates:
+#       - "--platform=linux/arm/v7"
+#       - "--label=org.opencontainers.image.created={{.Date}}"
+#       - "--label=org.opencontainers.image.title={{.ProjectName}}"
+#       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+#       - "--label=org.opencontainers.image.version={{.Version}}"
+
+# docker_manifests:
+#   # https://goreleaser.com/customization/docker_manifest/
+#   - name_template: ziggie1984/{{ .ProjectName }}:{{ .Version }}
+#     image_templates:
+#       - ziggie1984/{{ .ProjectName }}:{{ .Version }}-amd64
+#       - ziggie1984/{{ .ProjectName }}:{{ .Version }}-arm64v8
+#       - ziggie1984/{{ .ProjectName }}:{{ .Version }}-armv6
+#       - ziggie1984/{{ .ProjectName }}:{{ .Version }}-armv7
+#   - name_template: ziggie1984/{{ .ProjectName }}:latest
+#     image_templates:
+#       - ziggie1984/{{ .ProjectName }}:latest-amd64
+#       - ziggie1984/{{ .ProjectName }}:latest-arm64v8
+#       - ziggie1984/{{ .ProjectName }}:latest-armv6
+#       - ziggie1984/{{ .ProjectName }}:latest-armv7

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+FROM golang:1.19.2-alpine as builder 
+
+
+# Pass a tag, branch or a commit using build-arg.  This allows a docker
+# image to be built from a specified Git state.  The default image
+# will use the Git tip of master by default.
+ARG checkout="master"
+ARG git_url="https://github.com/rkfg/regolancer.git"
+
+
+# Install dependencies and build the binaries.
+RUN apk add --no-cache  git \
+    &&  git clone $git_url /go/src/github.com/regolancer \
+    &&  cd /go/src/github.com/regolancer \
+    &&  git checkout $checkout \
+    &&  go install 
+
+
+# Start a new, final image.
+FROM alpine as final
+
+
+RUN apk --no-cache add \
+    bash \
+    jq 
+
+
+WORKDIR /app
+
+COPY --from=builder /go/bin/regolancer /app
+
+
+
+
+VOLUME [ "/root/.lnd" ]
+
+ENTRYPOINT ["./regolancer"]
+

--- a/README.md
+++ b/README.md
@@ -195,6 +195,36 @@ payment is then done along this route and it should succeed. If, for whatever
 reason, it doesn't (liquidity shifted somewhere unexpectedly) the cycle
 continues.
 
+# Docker Setup
+
+In general its recommanded to run regolancer in a normal environment because it is
+so easy to install as mentioned above. However if you want to run it in a docker 
+we also provide the Dockerfile and a docker-compose.yml so that you can easily 
+get started. 
+
+Build the container or pull it:
+
+`docker build -t regolancer .` or `docker pull ziggie1984/regolancer
+
+Now you can use regolancer with your lnd instance:
+
+`docker run --rm --add-host=host.docker.internal:host-gateway -it -v /home/lnd:/root/.lnd regolancer --connect host.docker.internal:10009`
+
+The above command assumes /home/lnd is your lnd configuration directory. Please adjust as required.
+
+If you want to use a config file either copy the file into the mounted volume (/home/lnd) or mount a separate volume. Then just add the `--config /root/.lnd/config.toml` parameter to your start command
+
+**Note for Umbrel/Umbrel-OS users**
+
+`docker run --rm --network=umbrel_main_network -it -v /home/umbrel/umbrel/app-data/lightning/data/lnd:/root/.lnd regolancer --connect 10.21.21.9:10009`
+
+Optionally you can create an alias in your shell's environment file like so:
+
+alias regolancer="docker run --rm --network=umbrel_main_network -it -v /home/umbrel/umbrel/app-data/lightning/data/lnd:/root/.lnd regolancer --connect 10.21.21.9:10009"
+
+For older versions of Umbrel please use `/home/umbrel/umbrel/lnd` instead of `/home/umbrel/umbrel/app-data/lightning/data/lnd`
+
+
 # What's wrong with the other rebalancers
 
 While I liked probing in `bos`, it has many downsides: gives up quickly on

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/lightninglabs/lndclient v0.15.1-0
 	github.com/lightningnetwork/lnd v0.15.1-beta.rc1
+	github.com/mattn/go-runewidth v0.0.14
 	golang.org/x/sys v0.1.0
 )
 
@@ -83,7 +84,6 @@ require (
 	github.com/ltcsuite/ltcd v0.0.0-20190101042124-f37f8bf35796 // indirect
 	github.com/mattn/go-colorable v0.1.9 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
-	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/mholt/archiver/v3 v3.5.0 // indirect
 	github.com/miekg/dns v1.1.43 // indirect

--- a/goreleaser.md
+++ b/goreleaser.md
@@ -1,0 +1,33 @@
+# How to Create Releases with goreleaser
+
+Before you can use goreleaser you first need to install it: https://goreleaser.com/install/
+
+In case you want to create a test release just create a snapshot build with:
+
+`goreleaser release --snapshot --rm-dist`
+
+This will only create a release version locally.
+
+One can only build all the target or only one specific target:
+
+`GOOS=linux GOARCH=amd64 goreleaser build --rm-dist`
+
+Currently the CHANGE.LOG of the goreleaser is enabled to remove it go to the `.goreleaser.yaml` and change the setting.
+
+If you verified that the snapshot version is good to go than you can create a final release 
+
+First you need to get a github token with at least the privilige of write:packages
+
+`export GITHUB_TOKEN="YOUR_GH_TOKEN"`
+
+detailed information how to create a release with a speicific tag can be found here: https://goreleaser.com/quick-start/
+
+```
+git tag -a v0.1.0 -m "Release Comment"
+
+goreleaser release
+
+```
+
+Currently Docker Releases are turned off, but can be decided otherwise
+


### PR DESCRIPTION
This PR adds a simple Dockerfile for the regolancer project and describes docker usage in the README.

It additionally adds goreleaser support which creates binaries for different targets in an automatic fashion and simplifies the release process. It also includes the ability to push Docker Images to the Docker Hub in case we decide to host them there. For this we need a separate Regolancer account in the docker hub registry.

Happy to receive feedback, thanks ! 