### PR TITLE
Rapid rebalance strategy - Squeezing every sats out of a route

### DIFF
--- a/main.go
+++ b/main.go
@@ -256,6 +256,7 @@ func preflightChecks(params *configParams) error {
 	if params.TimeoutRoute == 0 {
 		params.TimeoutRoute = 30
 	}
+
 	return nil
 
 }

--- a/payment.go
+++ b/payment.go
@@ -19,7 +19,10 @@ func (e ErrRetry) Error() string {
 	return fmt.Sprintf("retry payment with %d sats", e.amount)
 }
 
-var ErrProbeFailed = fmt.Errorf("probe failed")
+var (
+	ErrProbeFailed = fmt.Errorf("probe failed")
+	ErrFeeExceeded = fmt.Errorf("fee-limit exceeded")
+)
 
 func (r *regolancer) createInvoice(ctx context.Context, amount int64) (result *lnrpc.AddInvoiceResponse, err error) {
 	var ok bool
@@ -45,7 +48,7 @@ func (r *regolancer) pay(ctx context.Context, amount int64, minAmount int64, max
 
 	if route.TotalFeesMsat > maxFeeMsat {
 		log.Printf("fee on the route exceeds our limits: %s ppm (max fee %s ppm)", formatFeePPM(amount*1000, route.TotalFeesMsat), formatFeePPM(amount*1000, maxFeeMsat))
-		return fmt.Errorf("fee-limit exceeded")
+		return ErrFeeExceeded
 	}
 
 	invoice, err := r.createInvoice(ctx, amount)


### PR DESCRIPTION
This is a preliminary PR for other users to also test the new rapid rebalance strategy. Which basically does the follwing:

When a route is found it will rebalance with an increasing amount (doubling), the new thing is, that it will go down to the min amount when decreasing the amount again. Only potential downside is, that you will try more routes hence failing more routes if no liquidity is available, but from my personal experience it's definitely worth the cost.