### PR TITLE
Probing

### DIFF
--- a/main.go
+++ b/main.go
@@ -256,6 +256,7 @@ func preflightChecks(params *configParams) error {
 	if params.TimeoutRoute == 0 {
 		params.TimeoutRoute = 30
 	}
+
 	return nil
 
 }

--- a/payment.go
+++ b/payment.go
@@ -19,7 +19,10 @@ func (e ErrRetry) Error() string {
 	return fmt.Sprintf("retry payment with %d sats", e.amount)
 }
 
-var ErrProbeFailed = fmt.Errorf("probe failed")
+var (
+	ErrProbeFailed = fmt.Errorf("probe failed")
+	ErrFeeExceeded = fmt.Errorf("fee-limit exceeded")
+)
 
 func (r *regolancer) createInvoice(ctx context.Context, amount int64) (result *lnrpc.AddInvoiceResponse, err error) {
 	var ok bool
@@ -45,7 +48,7 @@ func (r *regolancer) pay(ctx context.Context, amount int64, minAmount int64, max
 
 	if route.TotalFeesMsat > maxFeeMsat {
 		log.Printf("fee on the route exceeds our limits: %s ppm (max fee %s ppm)", formatFeePPM(amount*1000, route.TotalFeesMsat), formatFeePPM(amount*1000, maxFeeMsat))
-		return fmt.Errorf("fee-limit exceeded")
+		return ErrFeeExceeded
 	}
 
 	invoice, err := r.createInvoice(ctx, amount)


### PR DESCRIPTION
Before sending a rebalancing invoice a probing of the  route is done. In case of a timeout an invalid invoice will be created, so that the algo can exclude the route.
The extension of probing is done to minimise the risk if stucked htlcs.

When an HTLC (Hashed Time-Lock Contract) gets stuck, it's typically due to one of two reasons: either a node along the route is offline or unresponsive, or there is a pending channel closure along the route.

In the case of an offline or unresponsive node, the probeRoute function will generally not return a specific failure code. Instead, the request will time out, which will result in a context deadline exceeded error. This is an indirect indication that an HTLC may be stuck due to an unresponsive node.

When there's a pending channel closure, the lnrpc.Failure_TEMPORARY_CHANNEL_FAILURE failure code might be returned, since the channel cannot forward the payment. However, this failure code is quite generic and can be returned in many other scenarios as well, so it's not a definitive indication of a pending channel closure.

There is no specific failure code that unequivocally signals a stuck HTLC. Detecting stuck HTLCs usually involves looking for indirect signs like a context deadline exceeded error or a TEMPORARY_CHANNEL_FAILURE error. Furthermore, the Lightning Network's error reporting is intentionally obfuscated to some extent due to privacy considerations, which can make it harder to diagnose the exact cause of a payment failure.